### PR TITLE
feat: add Zero Fabrication Policy layer for AI-assisted CV tailoring

### DIFF
--- a/.claude/agents/resumx-audit.md
+++ b/.claude/agents/resumx-audit.md
@@ -1,0 +1,84 @@
+---
+name: resumx-audit
+description: |
+  Use this agent to audit a tailored resume output against the master resume.md.
+  Detects any fabricated, embellished, or unsourced claims.
+
+  Examples:
+  - "Audit the tailored resume for Stripe against my master"
+  - "Check Resume-Company-Role.md for any fabrications"
+  - "Run a ZFP audit on this output"
+model: sonnet
+color: orange
+---
+
+You are a forensic resume auditor. Your sole job is to compare a tailored resume
+output against the master `resume.md` and flag any content that violates the
+Zero Fabrication Policy.
+
+---
+
+## HARD CONSTRAINTS
+
+1. You are read-only. Do not modify any files.
+2. Every finding must cite the exact line from the tailored file and the expected
+   source in `resume.md` (or flag it as "no source found").
+3. Do not flag stylistic rewrites as violations — only flag substantive changes
+   that add, inflate, or fabricate claims.
+
+---
+
+## Audit Steps
+
+### Step 1: Read Both Files
+- `resume.md` — master source of truth
+- The tailored file to audit (`tailored/Resume-[Company]-[Role].md`)
+
+### Step 2: Metric Audit
+For every quantified claim in the tailored file (numbers, %, $, team sizes,
+time periods, scale figures):
+- Locate the corresponding bullet in `resume.md`
+- Verify the number is identical (or a direct subset)
+- Flag if the number was changed, rounded up, or does not exist in the source
+
+### Step 3: Skills Audit
+For every skill, technology, tool, or certification in the tailored file:
+- Verify it appears in `resume.md`
+- Flag any skill that was added without a source entry
+
+### Step 4: SKIP Section Audit
+Verify no content from `<!-- agent-note: SKIP -->` sections appears in the output.
+
+### Step 5: Agent Note Compliance
+Verify all `<!-- agent-note: -->` directives in `resume.md` were respected.
+
+---
+
+## Audit Report Format
+
+```
+## ZFP Audit Report — [Tailored File]
+**Audited:** [filename]
+**Master:** resume.md
+**Result:** PASS / FAIL
+
+### 🔴 Violations (fabrications / embellishments)
+| Line | Tailored Claim | Source in resume.md | Verdict |
+|---|---|---|---|
+| 42 | "Reduced latency by 60%" | "Reduced latency by 40%" <!-- verified --> | INFLATED |
+| 67 | "Kubernetes" | Not found in resume.md | FABRICATED |
+
+### 🟡 Warnings (minor rewrites that may change meaning)
+| Line | Tailored Claim | Original | Risk |
+|---|---|---|---|
+
+### ✅ Verified Clean
+- All other quantified bullets trace back to <!-- verified --> source
+- No SKIP sections included
+- All agent-notes respected
+
+### Summary
+- Violations: X
+- Warnings: Y
+- Recommendation: [APPROVE / REVISE BEFORE USE]
+```

--- a/.claude/agents/resumx-tailor.md
+++ b/.claude/agents/resumx-tailor.md
@@ -1,0 +1,138 @@
+---
+name: resumx-tailor
+description: |
+  Use this agent when tailoring resume.md for a specific job description.
+  Enforces the Zero Fabrication Policy — all output is strictly sourced
+  from the master resume.md. No metrics, skills, or claims may be inferred,
+  estimated, or embellished.
+
+  Examples:
+  - "Tailor my resume for the Stripe infrastructure role"
+  - "Generate a targeted resume.md for the backend engineer JD"
+  - "Adapt my resume for Job_Description-Company-Role.md"
+model: sonnet
+color: teal
+---
+
+You are a precise resume tailoring agent operating under strict sourcing constraints.
+Your role is to produce a tailored `resume.md` variant for a specific job description,
+using ONLY content explicitly present in the master `resume.md`.
+
+---
+
+## HARD CONSTRAINTS — These Override Everything
+
+1. **Only use content explicitly present in `resume.md`.** Do not infer, embellish,
+   generalize, or extrapolate beyond what is written.
+2. **Never add, estimate, or approximate metrics.** If a number is not in the source
+   file on a `<!-- verified -->` bullet, omit it. Do not ask the user to estimate.
+3. **Respect all `<!-- agent-note: -->` directives** in `resume.md` as binding
+   instructions. They override this prompt.
+4. **Skip any section marked** `<!-- agent-note: SKIP THIS SECTION -->` entirely.
+5. **If `<!-- verified-only -->` appears at the top of `resume.md`**, only include
+   quantified bullets that carry the `<!-- verified -->` tag.
+6. **Never ask the user for information.** Everything you need is in the source files.
+
+---
+
+## Step 1: Read Source Files
+
+Read in this order before writing anything:
+
+1. `resume.md` in the project root — single source of truth for all content
+2. The job description file (`Job_Description-[Company]-[Role].md`)
+
+Scan `resume.md` for:
+- `<!-- verified-only -->` at the top (activates strict metric mode)
+- All `<!-- agent-note: -->` directives (bind immediately)
+- All `<!-- agent-note: SKIP -->` sections (exclude entirely)
+- All `<!-- verified -->` bullets (the only source for quantified claims)
+- All Resumx tags (`{.@backend}`, `{.@ai}`, `{.@frontend}`, etc.)
+
+---
+
+## Step 2: Job Description Analysis
+
+Extract from the JD:
+- Required and preferred hard skills + technologies
+- Soft skills and leadership signals
+- Role-specific keywords and domain terminology
+- Seniority level and scope of responsibilities
+
+Build a keyword map. For each keyword, check if it maps to an existing bullet
+in `resume.md`. **Only include keywords you can trace to existing content.**
+If a JD keyword has no match in the source file, omit it — do not insert it freely.
+
+---
+
+## Step 3: Content Selection
+
+Select content from `resume.md` that:
+- Matches the JD's requirements and keywords
+- Is tagged with the most relevant Resumx target tags
+- Represents measurable impact (only from `<!-- verified -->` bullets)
+- Is from recent, relevant positions
+
+Exclude:
+- Any section with `<!-- agent-note: SKIP THIS SECTION -->`
+- Skills, tools, or experiences not relevant to this specific role
+- Unverified quantified claims (when `<!-- verified-only -->` is active)
+
+---
+
+## Step 4: Tailored Output
+
+Produce a tailored `resume.md` variant. Preserve the original Resumx format:
+- Keep `{.@tag}` annotations intact
+- Preserve `<!-- verified -->` markers on bullets you include
+- Add a new target tag `{.@[company-role]}` to selected bullets
+- Output file: `tailored/Resume-[Company]-[Role].md`
+
+Writing rules:
+- Every experience bullet starts with a strong action verb
+- Zero personal pronouns (I, me, my, we, our)
+- Present tense for current role, past tense for all others
+- Achievement-focused, not task-focused
+- Do NOT rewrite bullets to add impact language that wasn't there — preserve original wording
+- You may tighten phrasing for conciseness but never change the substance
+
+---
+
+## Step 5: Traceability Report
+
+After generating the tailored output, produce a short traceability report:
+
+```
+## ZFP Traceability Report — [Company] [Role]
+
+**Source:** resume.md
+**Target:** tailored/Resume-[Company]-[Role].md
+**Date:** [today]
+
+### Included Sections
+- [list of roles/sections included]
+
+### Excluded Sections
+- [list of sections excluded and why]
+
+### Keyword Mapping
+| JD Keyword | Mapped To | Bullet |
+|---|---|---|
+| Python | Skills > Languages | "Python, Node.js..." |
+| CI/CD | DevOps Experience | "Built CI/CD pipeline..." <!-- verified --> |
+| [keyword with no match] | OMITTED — no source in resume.md | — |
+
+### Fabrication Check
+- [ ] Zero metrics added or estimated
+- [ ] Zero skills inserted without source
+- [ ] All agent-notes respected
+- [ ] All SKIP sections excluded
+```
+
+---
+
+## Action Verbs
+
+Use strong action verbs: Architected, Optimized, Delivered, Reduced, Spearheaded,
+Implemented, Mentored, Streamlined, Automated, Deployed, Designed, Led, Built,
+Migrated, Integrated. Never start a bullet with "Responsible for..."

--- a/ZERO_FABRICATION.md
+++ b/ZERO_FABRICATION.md
@@ -1,0 +1,128 @@
+# Zero Fabrication Policy for Resumx
+
+> Ported and adapted from [ats-resume-agent](https://github.com/NullSpace-BitCradle/ats-resume-agent) by NullSpace-BitCradle.
+
+## The Core Principle
+
+**Your `resume.md` is an immutable database. Claude is the renderer, not the author.**
+
+When Claude tailors your resume for a job description, it may only:
+- **Select** bullets that are relevant to the role
+- **Filter** content by Resumx tags (`{.@backend}`, `{.@ai}`, etc.)
+- **Reorder** sections for emphasis
+- **Mirror** job description keywords — but only map them to bullets that already exist
+
+Claude may **never**:
+- Estimate, approximate, or suggest metrics not present in `resume.md`
+- Add skills, tools, or experiences not explicitly written in the source file
+- Paraphrase in a way that inflates, generalizes, or embellishes a claim
+- Ask you to "estimate conservatively" — if a number isn't there, it's omitted
+
+This is a **hard constraint**, not a suggestion.
+
+---
+
+## Annotation Syntax
+
+Annotate your `resume.md` bullets with these special comment markers. Claude agents
+read and respect these as binding instructions.
+
+### Verified Metrics Tag
+Use `<!-- verified -->` to mark any bullet containing a quantified achievement
+that you can back up with evidence. Claude may only use quantified claims from
+bullets carrying this tag.
+
+```markdown
+- Reduced API latency by 40% via Redis caching layer {.@backend} <!-- verified -->
+- Led team of 8 engineers across 3 time zones {.@backend}{.@leadership} <!-- verified -->
+- Built streaming pipeline handling 10k concurrent connections {.@backend} <!-- verified -->
+```
+
+Bullets **without** `<!-- verified -->` will be included as-is — Claude will
+not attempt to add, infer, or invent a metric for them.
+
+### Agent Notes
+Use `<!-- agent-note: YOUR INSTRUCTION -->` to embed binding directives for Claude.
+These override any other instruction in the prompt.
+
+```markdown
+<!-- agent-note: Do not include this role in senior engineering applications -->
+### Junior Dev — Startup XYZ (2015–2017)
+```
+
+```markdown
+<!-- agent-note: Use this summary only for DevOps and infrastructure roles -->
+> Cloud-native infrastructure engineer with 8 years...
+```
+
+### Skip Sections
+Mark entire sections that Claude must never include in any tailored output:
+
+```markdown
+<!-- agent-note: SKIP THIS SECTION - legacy technologies, do not include -->
+## Legacy Skills
+- COBOL, Fortran, VBA, Classic ASP
+```
+
+### Verified-Only Mode
+Add `<!-- verified-only -->` at the top of your `resume.md` to instruct Claude
+that it may **only** include bullets tagged `<!-- verified -->` when writing
+quantified impact statements.
+
+```markdown
+<!-- verified-only -->
+# Your Name
+...
+```
+
+---
+
+## Claude Agent Files
+
+This repo ships with two Claude agent definitions under `.claude/agents/`:
+
+| Agent | Purpose |
+|---|---|
+| `resumx-tailor.md` | Tailors `resume.md` for a specific job description with ZFP enforced |
+| `resumx-audit.md` | Audits a tailored output against the master `resume.md` for fabrications |
+
+See `docs/zero-fabrication/` for prompt templates if you use Claude directly
+(API, Claude.ai, etc.) rather than Claude Code.
+
+---
+
+## Workflow
+
+```
+1. Write your master resume.md once
+   └─ Annotate every quantified bullet with <!-- verified -->
+   └─ Add <!-- agent-note: SKIP --> to legacy/irrelevant sections
+   └─ Optionally add <!-- verified-only --> at the top
+
+2. Drop a job description file: Job_Description-Company-Role.md
+
+3. Run the tailor agent (Claude Code):
+   > Tailor my resume for the [Company] file
+
+4. Agent outputs a tailored resume.md variant with only relevant,
+   verified content — no fabricated metrics, no embellished claims
+
+5. Build with Resumx:
+   > resumx resume.md --for company-role
+
+6. Optional audit pass:
+   > Audit this tailored resume against my master resume.md
+```
+
+---
+
+## Pre-Delivery Checklist
+
+Before building a final PDF, verify:
+
+- [ ] Every quantified metric in the output traces back to a `<!-- verified -->` bullet in `resume.md`
+- [ ] No skills, tools, or technologies were added that don't exist in `resume.md`
+- [ ] No `<!-- agent-note: SKIP -->` sections appear in the output
+- [ ] No metric was paraphrased in a way that inflates the original number
+- [ ] All inline `<!-- agent-note: -->` directives were respected
+- [ ] Job description keywords were mapped only to existing content, not inserted freely

--- a/docs/zero-fabrication/AUDIT_PROMPT.md
+++ b/docs/zero-fabrication/AUDIT_PROMPT.md
@@ -1,0 +1,66 @@
+# Claude Audit Prompt — Zero Fabrication Policy
+
+Use this prompt to verify a tailored resume output contains no fabricated,
+estimated, or embellished claims before building your final PDF.
+
+---
+
+## Audit Prompt (copy-paste into Claude)
+
+```
+You are a forensic resume auditor enforcing the Zero Fabrication Policy.
+
+## Your Task
+
+Compare the TAILORED RESUME against the MASTER RESUME and identify any violations:
+
+### Violation Types
+- FABRICATED: content in tailored resume has no source in master resume
+- INFLATED: a metric was increased, rounded up, or exaggerated
+- HALLUCINATED SKILL: a technology, tool, or certification was added without source
+- SKIPPED SECTION LEAKED: content from a <!-- agent-note: SKIP --> section appeared
+- AGENT NOTE VIOLATED: a <!-- agent-note: --> directive was not followed
+
+### What is NOT a violation
+- Tighter phrasing that preserves the original meaning
+- Reordering bullets within a role
+- Removing irrelevant bullets
+- Adding stronger action verbs at the start of a bullet
+
+## Output Format
+
+### ZFP Audit Report
+**Result:** PASS / FAIL
+
+#### 🔴 Violations
+| Line | Tailored Claim | Source in Master | Type |
+|---|---|---|---|
+
+#### 🟡 Warnings
+| Line | Tailored Claim | Original | Risk |
+|---|---|---|---|
+
+#### ✅ Clean Items
+[list of verified-clean quantified bullets]
+
+#### Recommendation
+APPROVE — safe to build PDF
+or
+REVISE — fix violations before building PDF
+```
+
+---
+
+## How to Use
+
+```
+Here is my master resume.md:
+
+[paste resume.md]
+
+Here is the tailored resume to audit:
+
+[paste tailored resume]
+
+Please run a ZFP audit.
+```

--- a/docs/zero-fabrication/CLAUDE_USAGE.md
+++ b/docs/zero-fabrication/CLAUDE_USAGE.md
@@ -1,0 +1,424 @@
+# Claude Usage Guide — Zero Fabrication Policy
+
+This guide covers every way to use Claude with your Resumx resume under the
+Zero Fabrication Policy: Claude Code agents, direct API, and Claude.ai.
+
+---
+
+## The Golden Rule
+
+Before anything else, understand the model:
+
+```
+resume.md  →  Claude (renderer)  →  tailored/Resume-Company-Role.md  →  resumx build  →  PDF
+     ↑
+  ONLY source of truth
+  Claude never adds content here
+```
+
+**Claude's job:** select, filter, reorder, mirror keywords — never invent.
+
+---
+
+## Method 1 — Claude Code Agents (Recommended)
+
+This is the most powerful and automated path. The ZFP constraints are baked
+directly into the agent system prompts — you don't need to repeat them.
+
+### Prerequisites
+
+- Claude Code installed (`claude --version`)
+- `.claude/agents/resumx-tailor.md` and `.claude/agents/resumx-audit.md`
+  present in your resume project directory (see `SETUP.md` Step 6)
+
+### Setup
+
+```bash
+cd ~/my-resume
+claude   # starts Claude Code in your resume project
+```
+
+---
+
+### Phase 1 — Annotate Your Master Resume
+
+Before any tailoring, your `resume.md` must be properly annotated.
+You only do this once.
+
+**Open `resume.md` and:**
+
+1. Add `<!-- verified-only -->` at the very top:
+   ```markdown
+   <!-- verified-only -->
+   <!-- ZFP: All AI generation governed by Zero Fabrication Policy -->
+   ```
+
+2. Tag every bullet that contains a real, backed-up metric:
+   ```markdown
+   - Reduced API response time by 40% via Redis caching {.@backend} <!-- verified -->
+   - Led team of 12 engineers across 3 countries {.@leadership} <!-- verified -->
+   - Built CI/CD pipeline reducing deploy time from 45min to 8min {.@devops} <!-- verified -->
+   ```
+
+3. Mark sections Claude must always skip:
+   ```markdown
+   <!-- agent-note: SKIP THIS SECTION - legacy technologies -->
+   ## Legacy Skills
+   - COBOL, VBA, Classic ASP
+   ```
+
+4. Add per-role agent notes where needed:
+   ```markdown
+   <!-- agent-note: Do not include in senior engineering applications -->
+   ### Junior Dev — Startup XYZ (2015–2017)
+   ```
+
+---
+
+### Phase 2 — Create a Job Description File
+
+For each job you're applying to, create a dedicated JD file:
+
+```bash
+touch Job_Description-Stripe-Backend.md
+```
+
+Paste the full job description into it:
+
+```markdown
+# Stripe — Backend Engineer, Infrastructure
+
+## About the Role
+We're looking for a backend engineer to join our infrastructure team...
+
+## Requirements
+- 5+ years backend experience
+- Strong Python or Go skills
+- Experience with distributed systems
+- CI/CD pipeline experience
+...
+```
+
+Naming convention: `Job_Description-[Company]-[Role].md`
+
+---
+
+### Phase 3 — Tailor with the ZFP Agent
+
+In your Claude Code session:
+
+```
+Tailor my resume for the Stripe Backend file
+```
+
+The `resumx-tailor` agent will:
+1. Read your `resume.md` and parse all annotations
+2. Read `Job_Description-Stripe-Backend.md`
+3. Build a keyword map (only mapping to content that actually exists)
+4. Select the most relevant bullets and sections
+5. Output `tailored/Resume-Stripe-Backend.md`
+6. Print a **ZFP Traceability Report** showing every keyword mapping and confirming zero metrics were added
+
+**Example traceability report output:**
+```
+## ZFP Traceability Report — Stripe Backend
+
+| JD Keyword      | Mapped To          | Source Bullet                                |
+|---|---|---|
+| Python          | Skills > Languages | "Python, Node.js, TypeScript"                |
+| CI/CD           | DevOps Experience  | "Built CI/CD pipeline..." <!-- verified -->  |
+| Distributed sys | Cloud Arch role    | "Architected microservices..." <!-- verified --> |
+| Kubernetes      | OMITTED            | no source in resume.md                       |
+
+Fabrication check:
+✅ Zero metrics added or estimated
+✅ Zero skills inserted without source
+✅ All agent-notes respected
+✅ All SKIP sections excluded
+```
+
+If a JD keyword appears as **OMITTED**, that's the policy working correctly —
+the skill wasn't in your resume so it wasn't inserted.
+
+---
+
+### Phase 4 — Audit the Output
+
+After tailoring, run the audit agent to verify nothing slipped through:
+
+```
+Audit the tailored resume for Stripe against my master
+```
+
+The `resumx-audit` agent reads both files forensically and outputs:
+
+```
+## ZFP Audit Report — tailored/Resume-Stripe-Backend.md
+Result: PASS
+
+🔴 Violations: none
+🟡 Warnings: none
+✅ All quantified bullets trace back to <!-- verified --> source
+
+Recommendation: APPROVE — safe to build PDF
+```
+
+If you get a **FAIL**, the agent will show exactly which line was inflated or
+fabricated, so you can fix it before building.
+
+---
+
+### Phase 5 — Build the PDF
+
+Once the audit passes:
+
+```bash
+resumx tailored/Resume-Stripe-Backend.md
+# or pass a specific --for target if you used tags:
+resumx resume.md --for stripe-backend
+```
+
+Your PDF lands in `output/`.
+
+---
+
+### Iteration Loop
+
+Common follow-up commands in Claude Code after initial generation:
+
+```
+# Adjust tone or emphasis
+Make the summary more focused on distributed systems leadership
+
+# Add a specific bullet you forgot
+Add the Kafka migration project from my master resume to the Stripe variant
+
+# Fix an audit violation
+The audit flagged line 42 — fix it to match the exact metric in resume.md
+
+# Generate cover letter (ZFP also applies)
+Generate a cover letter for the Stripe role using only content from resume.md
+
+# Re-audit after changes
+Re-audit the updated tailored resume for Stripe
+```
+
+---
+
+## Method 2 — Claude API (Python / Node.js)
+
+Use this when you want to integrate ZFP tailoring into a script or pipeline.
+
+### Python Example
+
+```python
+import anthropic
+
+client = anthropic.Anthropic(api_key="sk-ant-...")
+
+# Load files
+with open("resume.md") as f:
+    master_resume = f.read()
+
+with open("Job_Description-Stripe-Backend.md") as f:
+    job_description = f.read()
+
+# Load the ZFP system prompt
+with open("docs/zero-fabrication/TAILORING_PROMPT.md") as f:
+    # Extract the prompt block between the triple backticks
+    raw = f.read()
+    system_prompt = raw.split("```")[1].strip()  # pulls the system prompt block
+
+# Run tailoring
+response = client.messages.create(
+    model="claude-sonnet-4-5",
+    max_tokens=4096,
+    system=system_prompt,
+    messages=[
+        {
+            "role": "user",
+            "content": f"""Here is my master resume.md:
+
+{master_resume}
+
+Here is the job description:
+
+{job_description}
+
+Please tailor my resume for this role following the Zero Fabrication Policy."""
+        }
+    ]
+)
+
+tailored = response.content[0].text
+
+# Save output
+with open("tailored/Resume-Stripe-Backend.md", "w") as f:
+    f.write(tailored)
+
+print("Tailored resume saved to tailored/Resume-Stripe-Backend.md")
+```
+
+### Node.js / TypeScript Example
+
+```typescript
+import Anthropic from "@anthropic-ai/sdk";
+import fs from "fs";
+
+const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+const masterResume = fs.readFileSync("resume.md", "utf-8");
+const jobDescription = fs.readFileSync(
+  "Job_Description-Stripe-Backend.md",
+  "utf-8"
+);
+
+// Load ZFP system prompt from the prompt template file
+const templateRaw = fs.readFileSync(
+  "docs/zero-fabrication/TAILORING_PROMPT.md",
+  "utf-8"
+);
+const systemPrompt = templateRaw.split("```")[1].trim();
+
+const response = await client.messages.create({
+  model: "claude-sonnet-4-5",
+  max_tokens: 4096,
+  system: systemPrompt,
+  messages: [
+    {
+      role: "user",
+      content: `Here is my master resume.md:\n\n${masterResume}\n\nHere is the job description:\n\n${jobDescription}\n\nTailor my resume following the Zero Fabrication Policy.`,
+    },
+  ],
+});
+
+const tailored = (response.content[0] as { text: string }).text;
+fs.writeFileSync("tailored/Resume-Stripe-Backend.md", tailored);
+console.log("Done.");
+```
+
+### Batch Script (multiple JDs at once)
+
+```bash
+#!/bin/bash
+# batch-tailor.sh — tailor all Job_Description-*.md files at once
+
+for jd_file in Job_Description-*.md; do
+  company_role=$(echo "$jd_file" | sed 's/Job_Description-//;s/.md//')
+  echo "→ Tailoring for $company_role..."
+  python3 tailor.py --jd "$jd_file" --output "tailored/Resume-${company_role}.md"
+  echo "  Building PDF..."
+  resumx "tailored/Resume-${company_role}.md"
+  echo "  ✅ output/Resume-${company_role}.pdf"
+done
+```
+
+---
+
+## Method 3 — Claude.ai (Browser)
+
+No API key required. Use this with the prompt templates in this repo.
+
+### Step-by-Step
+
+1. Open [claude.ai](https://claude.ai) and start a new conversation
+
+2. **Set the system prompt** (use Projects feature or paste at the start):
+   - Open `docs/zero-fabrication/TAILORING_PROMPT.md`
+   - Copy the entire block between the triple backticks
+   - Paste it as the first message with "System:" prefix, or use Claude Projects
+     to set it as a Project instruction
+
+3. **Send your tailoring request:**
+   ```
+   Here is my master resume.md:
+
+   [paste the full contents of your resume.md]
+
+   Here is the job description:
+
+   [paste the full job description]
+
+   Please tailor my resume for this role.
+   ```
+
+4. **Receive the tailored output** — Claude will return the tailored `resume.md`
+   variant and a ZFP Traceability Report table
+
+5. **Run the audit** in the same conversation (or a new one):
+   - Open `docs/zero-fabrication/AUDIT_PROMPT.md`
+   - Copy the audit prompt block
+   - Send:
+   ```
+   [paste audit prompt]
+
+   Here is my master resume.md:
+   [paste]
+
+   Here is the tailored resume to audit:
+   [paste Claude's output from step 4]
+   ```
+
+6. Save Claude's tailored output to `tailored/Resume-Company-Role.md`
+
+7. Build:
+   ```bash
+   resumx tailored/Resume-Company-Role.md
+   ```
+
+---
+
+## ZFP Annotation Quick Reference
+
+| Annotation | Where | Effect |
+|---|---|---|
+| `<!-- verified-only -->` | Top of `resume.md` | Strict mode: only `<!-- verified -->` bullets may carry quantified claims |
+| `<!-- verified -->` | End of a bullet line | Marks this bullet's metrics as backed-up and safe to use |
+| `<!-- agent-note: SKIP THIS SECTION -->` | Before a section heading | Claude skips entire section in all outputs |
+| `<!-- agent-note: Do not include in X roles -->` | Before a role block | Claude skips this role when generating X-type applications |
+| `<!-- agent-note: Use this summary only for Y roles -->` | Before a summary | Claude only uses this text for Y-type applications |
+| `{.@backend}` `{.@ai}` etc. | End of a bullet | Resumx target tag — Claude uses these to select relevant content |
+
+---
+
+## Full End-to-End Example
+
+```bash
+# 1. Start in your resume project
+cd ~/my-resume
+
+# 2. Drop the JD
+echo "[paste JD content]" > Job_Description-Anthropic-ML.md
+
+# 3. Open Claude Code
+claude
+
+# 4. Tailor
+> Tailor my resume for the Anthropic ML file
+
+# 5. Audit
+> Audit the tailored resume for Anthropic against my master
+
+# 6. If audit passes, build
+> exit
+resumx tailored/Resume-Anthropic-ML.md
+
+# 7. Open the PDF
+open output/Resume-Anthropic-ML.pdf   # macOS
+# or:
+xdg-open output/Resume-Anthropic-ML.pdf  # Linux
+```
+
+Total time from JD to PDF: **under 3 minutes**.
+Every claim in the output: **directly traceable to your resume.md**.
+
+---
+
+## Tips for Best Results
+
+- **More `<!-- verified -->` tags = stronger output.** The more you annotate, the more Claude has to work with.
+- **Be specific in agent notes.** `<!-- agent-note: Only include this in roles with >50% ML focus -->` is more useful than a vague note.
+- **Keep JD files clean.** Paste the raw job description without your personal notes — Claude reads everything in the file.
+- **Don't over-tag.** You don't need `{.@backend}` on every bullet. Tag intentionally so filtering produces focused variants.
+- **Version control your master.** Run `git commit resume.md` after every update. If a tailored version ever looks wrong, you can diff against any previous state.
+- **Run the audit before every PDF build.** It takes 30 seconds and can catch subtle fabrications introduced by iterative edits.

--- a/docs/zero-fabrication/README.md
+++ b/docs/zero-fabrication/README.md
@@ -1,0 +1,27 @@
+# Zero Fabrication Policy — Documentation
+
+This directory contains prompt templates and workflow guides for enforcing the
+Zero Fabrication Policy when using Claude (API, Claude.ai, or Claude Code) to
+tailor resumes built with Resumx.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `TAILORING_PROMPT.md` | Drop-in system prompt for Claude API / Claude.ai tailoring |
+| `AUDIT_PROMPT.md` | Drop-in prompt to audit tailored output for fabrications |
+| `RESUME_TEMPLATE.md` | Annotated `resume.md` template with ZFP syntax pre-filled |
+
+## Quick Start
+
+1. Copy `RESUME_TEMPLATE.md` → rename to `resume.md` in your Resumx project
+2. Fill in your real experience, tagging every quantified bullet with `<!-- verified -->`
+3. Use `TAILORING_PROMPT.md` as your system prompt when calling Claude
+4. After generation, run `AUDIT_PROMPT.md` to verify no fabrications slipped in
+5. Build your PDFs with `resumx resume.md --for [target]`
+
+If you use **Claude Code**, use the agents in `.claude/agents/` instead:
+```
+Tailor my resume for the [Company] file
+Audit the tailored resume for [Company] against my master
+```

--- a/docs/zero-fabrication/RESUME_TEMPLATE.md
+++ b/docs/zero-fabrication/RESUME_TEMPLATE.md
@@ -1,0 +1,97 @@
+<!-- verified-only -->
+<!-- ZFP: This resume.md is governed by the Zero Fabrication Policy -->
+<!-- Only Claude agents with ZFP constraints should tailor this file -->
+<!-- See ZERO_FABRICATION.md for full policy and annotation syntax -->
+
+# Your Name
+
+**Email:** you@example.com | **Phone:** +1 555 000 0000  
+**LinkedIn:** linkedin.com/in/yourhandle | **GitHub:** github.com/yourhandle  
+**Location:** City, Country
+
+---
+
+## Professional Summary {.@default}
+
+Write 2-3 sentences that describe your professional identity, core expertise,
+and value proposition. This is the only section where Claude may rephrase for
+tone — substance must remain unchanged.
+
+<!-- agent-note: Use this summary only for general / mixed-role applications -->
+
+---
+
+## Skills
+
+### Languages & Frameworks {.@backend}{.@frontend}{.@ai}
+- Python, Node.js, TypeScript, Java
+
+### Infrastructure & DevOps {.@backend}{.@devops}
+- Docker, Kubernetes, Nginx, Apache, GitHub Actions
+
+### Streaming & Media {.@streaming}
+- FFmpeg, RTMP, HLS, M3U8, WebRTC
+
+### AI & ML {.@ai}
+- LangChain, OpenAI API, Hugging Face, Prompt Engineering
+
+<!-- agent-note: SKIP THIS SECTION - legacy technologies, do not include in any tailored output -->
+### Legacy Skills
+- [Old tech you no longer use — always skipped by agents]
+
+---
+
+## Professional Experience
+
+### Company Name — Job Title {.@backend}{.@leadership}
+_Month Year – Present_
+
+- Architected and deployed [system] handling [X] concurrent users {.@backend} <!-- verified -->
+- Reduced [metric] by [N]% through [approach] {.@backend} <!-- verified -->
+- Led team of [N] engineers to deliver [outcome] within [timeframe] {.@leadership} <!-- verified -->
+- Built automation pipeline for [task], reducing manual effort {.@devops}
+  <!-- No metric on this bullet — Claude will not add one -->
+
+---
+
+### Company Name — Previous Role {.@backend}
+_Month Year – Month Year_
+
+- Implemented [feature/system] used by [N] users <!-- verified -->
+- Migrated [service] from [old] to [new], improving [outcome] {.@backend}
+
+<!-- agent-note: Do not include this role in senior/lead engineering applications -->
+
+---
+
+## Education
+
+### University Name
+_Degree, Field of Study — Year_
+
+---
+
+## Certifications
+
+- Certification Name — Issuing Body, Year <!-- verified -->
+
+---
+
+## Projects
+
+### Project Name {.@backend}{.@ai}
+_Brief one-line description_
+
+- Key technical detail or outcome <!-- verified (if has metric) -->
+- Tech stack: Python, Docker, Redis
+
+---
+
+## Notes for Tailoring
+
+<!-- These are human notes for your own reference, not agent directives -->
+
+- For DevOps roles: emphasize infrastructure and CI/CD bullets
+- For AI/ML roles: lead with the AI section and Projects
+- For backend roles: highlight the streaming and API work
+- For leadership roles: bring team size and delivery metrics to the top

--- a/docs/zero-fabrication/SETUP.md
+++ b/docs/zero-fabrication/SETUP.md
@@ -1,0 +1,299 @@
+# Local Setup Tutorial
+
+This guide walks you through setting up Resumx with the Zero Fabrication Policy
+layer from scratch on Linux, macOS, or WSL.
+
+---
+
+## Prerequisites Overview
+
+| Tool | Required | Purpose |
+|---|---|---|
+| Node.js ≥ 18 | ✅ | Resumx CLI runtime |
+| pnpm | ✅ | Package manager used by Resumx |
+| Playwright Chromium | ✅ | PDF rendering engine |
+| Git | ✅ | Version control for your resume |
+| Claude Code CLI | Optional | AI tailoring with ZFP agents |
+| Anthropic API key | Optional | Claude Code or direct API access |
+
+---
+
+## Step 1 — Clone Your Fork
+
+This repo is already forked at `MarvenAPPS/resumx`. Clone it locally:
+
+```bash
+git clone https://github.com/MarvenAPPS/resumx.git
+cd resumx
+```
+
+Switch to the Zero Fabrication branch:
+
+```bash
+git checkout feat/zero-fabrication-policy
+```
+
+Verify you can see the ZFP files:
+
+```bash
+ls ZERO_FABRICATION.md docs/zero-fabrication/ .claude/agents/
+```
+
+---
+
+## Step 2 — Install Node.js
+
+### Linux / WSL (recommended: nvm)
+
+```bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.0/install.sh | bash
+source ~/.bashrc   # or ~/.zshrc
+nvm install --lts
+nvm use --lts
+node --version     # should print v20.x or higher
+```
+
+### macOS
+
+```bash
+brew install node
+node --version
+```
+
+### Verify
+
+```bash
+node --version   # ≥ 18.0.0 required
+npm --version
+```
+
+---
+
+## Step 3 — Install pnpm
+
+Resumax uses pnpm workspaces internally. You need it to develop locally.
+
+```bash
+npm install -g pnpm
+pnpm --version   # should print 8.x or 9.x
+```
+
+---
+
+## Step 4 — Install Resumx CLI
+
+### Option A — Global install (recommended for end users)
+
+```bash
+npm install -g @resumx/resumx
+resumx --version
+```
+
+Install the Playwright Chromium browser (required for PDF rendering):
+
+```bash
+npx playwright install chromium
+```
+
+> **WSL note:** If you hit a missing system library error, install dependencies:
+> ```bash
+> npx playwright install-deps chromium
+> ```
+
+### Option B — Local dev install (if you want to modify Resumx source)
+
+```bash
+# from the repo root
+pnpm install
+pnpm run build
+```
+
+Then use the local binary:
+
+```bash
+node ./bin/resumx.js --version
+# or add a local alias:
+alias resumx="node $(pwd)/bin/resumx.js"
+```
+
+---
+
+## Step 5 — Initialize Your Resume
+
+Create your resume project directory. **Keep it separate from the Resumx repo.**
+
+```bash
+mkdir ~/my-resume
+cd ~/my-resume
+git init
+```
+
+Copy the Zero Fabrication annotated template as your starting point:
+
+```bash
+cp /path/to/resumx/docs/zero-fabrication/RESUME_TEMPLATE.md resume.md
+```
+
+Or generate a blank template with the CLI:
+
+```bash
+resumx init resume.md
+```
+
+Start the live preview:
+
+```bash
+resumx resume.md --watch
+# opens a browser tab with live-reloading preview
+```
+
+Edit `resume.md` with your real experience. As you save, the preview updates instantly.
+
+---
+
+## Step 6 — Add Claude Code Skills (Optional)
+
+Resumax ships a skills package that teaches Claude Code how to work with your resume.
+
+```bash
+# from your resume project directory
+npx skills add resumx/skills
+```
+
+This installs the Resumx-aware skill context into Claude Code so it understands
+tags, frontmatter, targets, and the build workflow.
+
+The ZFP agents (`.claude/agents/resumx-tailor.md` and `.claude/agents/resumx-audit.md`)
+should live in your **resume project directory**, not in the Resumx CLI repo.
+Copy them:
+
+```bash
+mkdir -p .claude/agents
+cp /path/to/resumx/.claude/agents/resumx-tailor.md .claude/agents/
+cp /path/to/resumx/.claude/agents/resumx-audit.md .claude/agents/
+```
+
+---
+
+## Step 7 — Install Claude Code (Optional)
+
+Claude Code is Anthropic's CLI that runs the ZFP agents defined in `.claude/agents/`.
+
+```bash
+curl -fsSL https://install.anthropic.com | sh
+claude --version
+```
+
+Authenticate with your Anthropic API key or Claude Pro/Max subscription:
+
+```bash
+claude auth login
+```
+
+Test it:
+
+```bash
+claude "What files are in this directory?"
+```
+
+> **API key setup (alternative):**
+> ```bash
+> export ANTHROPIC_API_KEY="sk-ant-..."
+> # add to ~/.bashrc or ~/.zshrc to persist
+> ```
+
+---
+
+## Step 8 — Build Your First Resume
+
+From your resume project directory:
+
+```bash
+# Live preview
+resumx resume.md --watch
+
+# Build PDF
+resumx resume.md
+
+# Build a tailored variant for a specific target
+resumx resume.md --for stripe-backend
+
+# Build multiple targets at once
+resumx resume.md --for stripe-backend,vercel-swe,startup-cto
+```
+
+Output files land in `output/` by default.
+
+---
+
+## Step 9 — Directory Structure
+
+Your resume project should look like this when fully set up:
+
+```
+my-resume/
+├── resume.md                          # Your master resume (MCD)
+├── Job_Description-Stripe-Backend.md  # Job description files
+├── Job_Description-Vercel-SWE.md
+├── tailored/                          # ZFP-tailored variants (Claude output)
+│   ├── Resume-Stripe-Backend.md
+│   └── Resume-Vercel-SWE.md
+├── output/                            # Built PDFs and HTML
+│   ├── Resume-Stripe-Backend.pdf
+│   └── Resume-Vercel-SWE.pdf
+└── .claude/
+    └── agents/
+        ├── resumx-tailor.md           # ZFP tailor agent
+        └── resumx-audit.md            # ZFP audit agent
+```
+
+`resume.md` and `Job_Description-*.md` files are gitignored in the `.gitignore`
+by default in this fork to prevent accidental personal data commits.
+
+Add them explicitly only if you intend to commit:
+
+```bash
+git add -f resume.md
+```
+
+---
+
+## Troubleshooting
+
+### Playwright browser not found
+
+```bash
+npx playwright install chromium
+# If on WSL or Debian-based Linux:
+npx playwright install-deps chromium
+```
+
+### `resumx: command not found`
+
+```bash
+npm install -g @resumx/resumx
+# or check your PATH:
+export PATH="$PATH:$(npm root -g)/../bin"
+```
+
+### PDF is blank or missing fonts
+
+Playwright Chromium handles fonts automatically. If fonts are missing on a headless
+Linux server:
+
+```bash
+sudo apt-get install -y fonts-liberation fonts-noto
+```
+
+### Claude Code auth fails
+
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."
+claude auth login
+```
+
+If you use Claude Pro/Max (browser subscription), authenticate via OAuth:
+
+```bash
+claude auth login --oauth
+```

--- a/docs/zero-fabrication/TAILORING_PROMPT.md
+++ b/docs/zero-fabrication/TAILORING_PROMPT.md
@@ -1,0 +1,85 @@
+# Claude Tailoring Prompt — Zero Fabrication Policy
+
+Use this as your **system prompt** when calling Claude (API or Claude.ai) to
+tailor your Resumx `resume.md` for a specific job description.
+
+---
+
+## System Prompt (copy-paste into Claude)
+
+```
+You are a precise resume tailoring assistant operating under the Zero Fabrication Policy.
+
+## HARD CONSTRAINTS — These override all other instructions
+
+1. You may only use content explicitly present in the master resume.md provided below.
+   Do not infer, embellish, generalize, or extrapolate beyond what is written.
+
+2. Never add, estimate, or approximate metrics.
+   If a number is not on a bullet tagged <!-- verified --> in the source file, omit it.
+   Do not ask the user to estimate conservatively. Omit, do not approximate.
+
+3. Respect all <!-- agent-note: --> directives in resume.md as binding instructions.
+   They override this prompt.
+
+4. Skip any section marked <!-- agent-note: SKIP THIS SECTION --> entirely.
+   Do not reference or include any content from those sections.
+
+5. If <!-- verified-only --> appears at the top of resume.md, only include
+   quantified claims from bullets tagged <!-- verified -->.
+
+6. When mapping job description keywords to the resume:
+   - Only include a keyword if you can directly trace it to an existing bullet.
+   - If a JD keyword has no match in resume.md, omit it entirely.
+   - Never insert a keyword as a skill or claim without source backing.
+
+7. Do not ask the user for additional information.
+   Everything needed is in the source files.
+
+## Your Task
+
+Given:
+- master_resume: the full contents of resume.md (provided by user)
+- job_description: the job description to tailor for (provided by user)
+
+Produce:
+1. A tailored resume.md variant with only the most relevant content selected
+   and tagged with a new Resumx target `{.@[company-role]}`.
+2. A traceability report confirming every quantified claim is sourced.
+
+## Traceability Report Format
+
+After the tailored resume, output:
+
+### ZFP Traceability Report
+| JD Keyword | Mapped To | Source Bullet |
+|---|---|---|
+| [keyword] | [section] | [exact bullet text] |
+| [keyword with no match] | OMITTED | no source in resume.md |
+
+Fabrication check:
+- [ ] Zero metrics added or estimated
+- [ ] Zero skills inserted without source
+- [ ] All agent-notes respected
+- [ ] All SKIP sections excluded
+```
+
+---
+
+## How to Use
+
+1. Start a Claude conversation
+2. Paste the system prompt above
+3. Then send:
+
+```
+Here is my master resume.md:
+
+[paste resume.md contents]
+
+Here is the job description:
+
+[paste JD]
+
+Please tailor my resume for this role.
+```


### PR DESCRIPTION
Ports the hard-constraint fabrication guard from ats-resume-agent into the Resumx workflow. Adds:
- ZERO_FABRICATION.md — full policy specification and annotation syntax
- docs/zero-fabrication/ — Claude prompt templates and audit workflow
- docs/zero-fabrication/RESUME_TEMPLATE.md — MCD-annotated resume.md template
- .claude/agents/resumx-tailor.md — Claude Code agent definition

All AI generation is now constrained to only render content that is explicitly present and verified in resume.md. No metrics, skills, or claims may be inferred, estimated, or embellished.